### PR TITLE
Initialize auth store and show session loader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,14 @@
 import { useEffect } from 'react';
 import { RouterProvider } from '@tanstack/react-router';
 import { router } from './router';
-import { supabase } from './lib/supabase';
-import { useAuthStore } from './store/authStore'; 
 import { useThemeStore } from './store/themeStore'; 
 
 function App() {
-  const setSession = useAuthStore((state) => state.setSession);
-  const setLoading = useAuthStore((state) => state.setLoading);
-  
   const initTheme = useThemeStore((state) => state.initTheme);
 
   useEffect(() => {
     initTheme();
   }, [initTheme]);
-
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-      setLoading(false);
-    });
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-      setLoading(false);
-    });
-
-    return () => subscription.unsubscribe();
-  }, [setSession, setLoading]);
 
   return <RouterProvider router={router} />;
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,19 +1,42 @@
-import { Outlet } from '@tanstack/react-router';
+import { Outlet, useRouter } from '@tanstack/react-router';
 import { Navbar } from '../components/Navbar';
 import { Footer } from '../components/Footer';
 import { CookieSettingsModal } from '../components/CookieSettingsModal';
 import { useCookieStore } from '../store/cookieStore';
+import { useAuthStore } from '../store/authStore';
 import { useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
 
 export const RootLayout = () => {
   const { hasConsent, openModal } = useCookieStore();
-  
+  const { initialize, session, isInitialized } = useAuthStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  useEffect(() => {
+    if (isInitialized) {
+      router.invalidate();
+    }
+  }, [session, isInitialized, router]);
+
   useEffect(() => {
      if (!hasConsent) {
         const timer = setTimeout(() => openModal(), 1000);
         return () => clearTimeout(timer);
      }
   }, [hasConsent, openModal]);
+
+  if (!isInitialized) {
+     return (
+       <div className="min-h-screen bg-bg-main flex flex-col items-center justify-center gap-4 transition-colors duration-300">
+          <Loader2 className="animate-spin text-primary" size={40} />
+          <p className="text-text-muted font-medium animate-pulse">Verifying secure session...</p>
+       </div>
+     );
+  }
 
   return (
     <div className="flex flex-col min-h-screen bg-bg-main text-text-main font-poppins transition-colors duration-300">

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,24 +1,32 @@
 import { create } from 'zustand';
-import type { Session, User } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
+import type { Session, User } from '@supabase/supabase-js';
 
 interface AuthState {
-  session: Session | null;
   user: User | null;
-  loading: boolean;
-  setSession: (session: Session | null) => void;
-  setLoading: (loading: boolean) => void;
+  session: Session | null;
+  isInitialized: boolean;
+  initialize: () => void;
   signOut: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  session: null,
   user: null,
-  loading: true, 
-  setSession: (session) => set({ session, user: session?.user ?? null }),
-  setLoading: (loading) => set({ loading }),
+  session: null,
+  isInitialized: false,
+
+  initialize: () => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      set({ session, user: session?.user ?? null, isInitialized: true });
+    });
+
+    supabase.auth.onAuthStateChange((_event, session) => {
+      set({ session, user: session?.user ?? null });
+    });
+  },
 
   signOut: async () => {
     await supabase.auth.signOut();
-  },
+    set({ session: null, user: null });
+  }
 }));


### PR DESCRIPTION
Add auth initialization and session handling via Supabase in authStore: introduce isInitialized and initialize(), fetch current session on startup, subscribe to onAuthStateChange, and clear session/user on signOut. Update RootLayout to call initialize(), render a centered loader (Loader2) while auth is being verified, and invalidate the router when initialization or session changes to refresh routes. Also keep existing cookie-consent behavior. These changes ensure the app verifies the secure session before rendering protected UI and avoids auth flicker.