### PR TITLE
Add loading/success states to profile & security

### DIFF
--- a/src/pages/setings/profile/ProfileSettings.tsx
+++ b/src/pages/setings/profile/ProfileSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Camera, Mail, Save, Loader2 } from 'lucide-react';
+import { Camera, Mail, Save, Loader2, CheckCircle } from 'lucide-react';
 import { supabase } from '../../../lib/supabase';
 import { profileSchema, type ProfileFormValues } from '../../../lib/validation';
 import { useToastStore } from '../../../store/useToastStore';
@@ -18,11 +18,12 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ userId, initialData }
   const [avatarUrl, setAvatarUrl] = useState<string | null>(initialData.avatarUrl || null);
   const [uploading, setUploading] = useState(false);
 
+  const [buttonStatus, setButtonStatus] = useState<'idle' | 'loading' | 'success'>('idle');
+
   const { 
     register, 
     handleSubmit, 
-    setValue, 
-    formState: { isSubmitting } 
+    setValue 
   } = useForm<ProfileFormValues>({ 
     resolver: zodResolver(profileSchema),
     defaultValues: {
@@ -61,7 +62,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ userId, initialData }
       if (updateError) throw updateError;
 
       setAvatarUrl(`${publicUrl}?t=${new Date().getTime()}`);
-      showToast('success', 'ავატარი განახლდა!');
+      showToast('success', 'ავატარი წარმატებით განახლდა!');
     } catch (error: unknown) {
       showToast('error', (error as Error).message || 'Error uploading avatar');
     } finally {
@@ -70,13 +71,25 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ userId, initialData }
   };
 
   const onUpdateProfile = async (data: ProfileFormValues) => {
+    setButtonStatus('loading');
+    
     try {
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
       const { error } = await supabase.from('profiles').upsert({
           id: userId, full_name: data.fullName, bio: data.bio, updated_at: new Date(),
         }).eq('id', userId);
       if (error) throw error;
-      showToast('success', 'პროფილი განახლდა!');
+      
+      setButtonStatus('success');
+      showToast('success', 'პროფილი წარმატებით განახლდა!');
+      
+      setTimeout(() => {
+        setButtonStatus('idle');
+      }, 2000);
+      
     } catch (error: unknown) {
+      setButtonStatus('idle');
       showToast('error', (error as Error).message || 'Error updating profile');
     }
   };
@@ -150,11 +163,19 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({ userId, initialData }
 
       <div className="pt-4 flex justify-end">
         <button 
-          type="submit" disabled={isSubmitting}
-          className="flex items-center gap-2 bg-primary text-white px-6 py-2.5 rounded-lg font-semibold hover:opacity-90 transition-all disabled:opacity-50 shadow-lg shadow-primary/25"
+          type="submit" 
+          disabled={buttonStatus !== 'idle'}
+          className={`flex items-center gap-2 px-6 py-2.5 rounded-lg font-semibold transition-all shadow-lg disabled:opacity-50 ${
+            buttonStatus === 'success'
+              ? 'bg-green-500 text-white shadow-green-500/25'
+              : 'bg-primary text-white hover:opacity-90 shadow-primary/25'
+          }`}
         >
-          {isSubmitting ? <Loader2 className="animate-spin" size={18} /> : <Save size={18} />} 
-          Save Changes
+          {buttonStatus === 'loading' && <Loader2 className="animate-spin" size={18} />} 
+          {buttonStatus === 'success' && <CheckCircle size={18} />} 
+          {buttonStatus === 'idle' && <Save size={18} />} 
+          
+          {buttonStatus === 'idle' ? 'Save Changes' : buttonStatus === 'loading' ? 'Saving...' : 'Saved!'}
         </button>
       </div>
     </form>

--- a/src/pages/setings/profile/SecuritySettings.tsx
+++ b/src/pages/setings/profile/SecuritySettings.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Lock, Loader2, Trash2, AlertTriangle } from 'lucide-react';
+import { Lock, Loader2, Trash2, AlertTriangle, CheckCircle } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
 import { supabase } from '../../../lib/supabase';
 import { passwordSchema, type PasswordFormValues } from '../../../lib/validation';
@@ -10,15 +10,31 @@ import { useToastStore } from '../../../store/useToastStore';
 const SecuritySettings: React.FC = () => { 
   const navigate = useNavigate();
   const { showToast } = useToastStore();
-  const { register, handleSubmit, reset, formState: { isSubmitting } } = useForm<PasswordFormValues>({ resolver: zodResolver(passwordSchema) });
+  const { register, handleSubmit, reset } = useForm<PasswordFormValues>({ resolver: zodResolver(passwordSchema) });
+
+  const [buttonStatus, setButtonStatus] = useState<'idle' | 'loading' | 'success'>('idle');
 
   const onUpdatePassword = async (data: PasswordFormValues) => {
+    setButtonStatus('loading');
+
     try {
+      await new Promise(resolve => setTimeout(resolve, 1500));
+
       const { error } = await supabase.auth.updateUser({ password: data.password });
       if (error) throw error;
+      
+      setButtonStatus('success');
       showToast('success', 'პაროლი წარმატებით განახლდა!');
       reset();
-    } catch (error: unknown) { showToast('error', (error as Error).message); }
+
+      setTimeout(() => {
+        setButtonStatus('idle');
+      }, 2000);
+
+    } catch (error: unknown) { 
+      setButtonStatus('idle');
+      showToast('error', (error as Error).message); 
+    }
   };
 
   const handleDeleteAccount = async () => {
@@ -29,7 +45,9 @@ const SecuritySettings: React.FC = () => {
       await supabase.auth.signOut();
       alert('ანგარიში წაიშალა.');
       navigate({ to: '/auth' });
-    } catch (error: unknown) { showToast('error', (error as Error).message); }
+    } catch (error: unknown) { 
+      showToast('error', (error as Error).message); 
+    }
   };
 
   return (
@@ -51,8 +69,18 @@ const SecuritySettings: React.FC = () => {
             />
           </div>
           <div className="flex justify-end mt-2">
-            <button type="submit" disabled={isSubmitting} className="text-sm bg-primary/10 text-primary px-4 py-2 rounded-lg hover:bg-primary/20 transition-colors font-medium flex items-center gap-2">
-               {isSubmitting && <Loader2 className="animate-spin" size={14} />} Update Password
+            <button 
+              type="submit" 
+              disabled={buttonStatus !== 'idle'} 
+              className={`text-sm px-4 py-2 rounded-lg transition-all font-medium flex items-center gap-2 ${
+                buttonStatus === 'success' 
+                  ? 'bg-green-500/20 text-green-500 border border-green-500/30' 
+                  : 'bg-primary/10 text-primary hover:bg-primary/20 border border-transparent'
+              }`}
+            >
+               {buttonStatus === 'loading' && <Loader2 className="animate-spin" size={16} />}
+               {buttonStatus === 'success' && <CheckCircle size={16} />}
+               {buttonStatus === 'idle' ? 'Update Password' : buttonStatus === 'loading' ? 'Updating...' : 'Saved!'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Introduce a buttonStatus state in ProfileSettings and SecuritySettings to show loading and success UI for save/update actions. Import CheckCircle icon and replace isSubmitting checks with buttonStatus-based disabled states, spinner, and success icons; update button labels and styles for idle/loading/success. Add short artificial delays for UX, ensure status resets on completion or error, and tweak toast messages (including updated Georgian success texts).